### PR TITLE
fix custom assertion for word-count

### DIFF
--- a/exercises/practice/word-count/.meta/example.moon
+++ b/exercises/practice/word-count/.meta/example.moon
@@ -5,6 +5,7 @@ trim = (str) -> str\gsub("^'+", '')\gsub("'+$", '')
     result = {}
     for word in sentence\lower!\gmatch("[%w+']+")
       w = trim word
-      result[w] = (result[w] or 0) + 1
+      if #w > 0
+        result[w] = (result[w] or 0) + 1
     result
 }

--- a/exercises/practice/word-count/.meta/spec_generator.moon
+++ b/exercises/practice/word-count/.meta/spec_generator.moon
@@ -7,8 +7,10 @@ import json_string, kv_table from require 'test_helpers'
   -- ----------------------------------------------------------
   same_kv = (state, arguments) ->
     actual = arguments[1]
+    return false if type(actual) != 'table'
     expected = arguments[2]
-    return false if #expected != #actual
+    size = (t) -> #[k for k, _ in pairs t]
+    return false if size(expected) != size(actual)
     for k, v in pairs expected
       return false if actual[k] != v
     true

--- a/exercises/practice/word-count/word_count_spec.moon
+++ b/exercises/practice/word-count/word_count_spec.moon
@@ -4,8 +4,10 @@ describe 'word-count', ->
   -- ----------------------------------------------------------
   same_kv = (state, arguments) ->
     actual = arguments[1]
+    return false if type(actual) != 'table'
     expected = arguments[2]
-    return false if #expected != #actual
+    size = (t) -> #[k for k, _ in pairs t]
+    return false if size(expected) != size(actual)
     for k, v in pairs expected
       return false if actual[k] != v
     true
@@ -26,8 +28,8 @@ describe 'word-count', ->
   pending 'count one of each word', ->
     result = count_words "one of each"
     expected = {
-      each: 1,
       of: 1,
+      each: 1,
       one: 1,
     }
     assert.has.same_kv result, expected
@@ -35,11 +37,11 @@ describe 'word-count', ->
   pending 'multiple occurrences of a word', ->
     result = count_words "one fish two fish red fish blue fish"
     expected = {
+      two: 1,
+      blue: 1,
       fish: 4,
       one: 1,
       red: 1,
-      blue: 1,
-      two: 1,
     }
     assert.has.same_kv result, expected
 
@@ -47,8 +49,8 @@ describe 'word-count', ->
     result = count_words "one,two,three"
     expected = {
       two: 1,
-      three: 1,
       one: 1,
+      three: 1,
     }
     assert.has.same_kv result, expected
 
@@ -56,28 +58,28 @@ describe 'word-count', ->
     result = count_words "one,\ntwo,\nthree"
     expected = {
       two: 1,
-      three: 1,
       one: 1,
+      three: 1,
     }
     assert.has.same_kv result, expected
 
   pending 'ignore punctuation', ->
     result = count_words "car: carpet as java: javascript!!&@$%^&"
     expected = {
-      carpet: 1,
-      javascript: 1,
-      as: 1,
       java: 1,
+      javascript: 1,
       car: 1,
+      carpet: 1,
+      as: 1,
     }
     assert.has.same_kv result, expected
 
   pending 'include numbers', ->
     result = count_words "testing, 1, 2 testing"
     expected = {
-      '1': 1,
-      testing: 2,
       '2': 1,
+      testing: 2,
+      '1': 1,
     }
     assert.has.same_kv result, expected
 
@@ -92,14 +94,14 @@ describe 'word-count', ->
   pending 'with apostrophes', ->
     result = count_words "'First: don't laugh. Then: don't cry. You're getting it.'"
     expected = {
-      first: 1,
-      it: 1,
-      laugh: 1,
-      "you're": 1,
-      cry: 1,
       then: 1,
+      it: 1,
       getting: 1,
+      "you're": 1,
       "don't": 2,
+      first: 1,
+      cry: 1,
+      laugh: 1,
     }
     assert.has.same_kv result, expected
 
@@ -107,25 +109,25 @@ describe 'word-count', ->
     result = count_words "Joe can't tell between 'large' and large."
     expected = {
       tell: 1,
-      and: 1,
-      large: 2,
       "can't": 1,
-      between: 1,
+      large: 2,
       joe: 1,
+      and: 1,
+      between: 1,
     }
     assert.has.same_kv result, expected
 
   pending 'substrings from the beginning', ->
     result = count_words "Joe can't tell between app, apple and a."
     expected = {
-      app: 1,
-      a: 1,
       tell: 1,
-      apple: 1,
-      and: 1,
       "can't": 1,
+      a: 1,
+      app: 1,
       between: 1,
       joe: 1,
+      and: 1,
+      apple: 1,
     }
     assert.has.same_kv result, expected
 
@@ -141,15 +143,15 @@ describe 'word-count', ->
     result = count_words ",\n,one,\n ,two \n 'three'"
     expected = {
       two: 1,
-      three: 1,
       one: 1,
+      three: 1,
     }
     assert.has.same_kv result, expected
 
   pending 'quotation for word with apostrophe', ->
     result = count_words "can, can't, 'can't'"
     expected = {
-      "can't": 2,
       can: 1,
+      "can't": 2,
     }
     assert.has.same_kv result, expected


### PR DESCRIPTION
Can't get the size of a Lua key-value table with the `#` operator. Have to count the pairs.